### PR TITLE
Adding Flyway to handle database schema creation and migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.1'
+services:
+  mysql:
+    image: mysql:5.7.21
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: java_prototype
+      MYSQL_PASSWORD: java_prototype
+    ports:
+      - "3306:3306"

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-server.port: ${port:8080}
-debug: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+server.port: ${port:8080}
+debug: true
+
+spring:
+  datasource:
+    url: ${JAVAPROTOTYPE_MYSQL_CONNECTION_STRING:jdbc:mysql://localhost:3306/java_prototype}
+    driver-class-name: com.mysql.jdbc.Driver
+    username: ${JAVAPROTOTYPE_MYSQL_CONNECTION_USER:java_prototype}
+    password: ${JAVAPROTOTYPE_MYSQL_CONNECTION_PASS:java_prototype}
+
+flyway:
+  url: jdbc:mysql://localhost:3306
+  schemas: java_prototype
+  placeholders:
+    application_username: ${spring.datasource.username}

--- a/src/main/resources/db/migration/V1__create_getrequests_table.sql
+++ b/src/main/resources/db/migration/V1__create_getrequests_table.sql
@@ -1,0 +1,10 @@
+
+GRANT delete, insert, select, update ON java_prototype.* TO ${application_username};
+
+-- Create syntax for 'java_prototype.getrequests'
+CREATE TABLE getrequests (
+  id int(11) unsigned NOT NULL AUTO_INCREMENT,
+  timestamp timestamp NULL DEFAULT NULL,
+  hash varchar(255) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB AUTO_INCREMENT=499 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This PR is intended to resolve https://github.com/heptio/java-prototype/issues/18

I also added a `docker-compose.yml` to make it easier to test things out locally against MySQL:

```bash
$ docker-compose up -d
$ mvn clean && FLYWAY_USER=root FLYWAY_PASSWORD=root mvn spring-boot:run
```

Some things to note:
* The MySQL Docker image creates the `java_prototype` user for (as defined in `docker-compose.yml`).  I'm assuming someone would be responsible for creating an account for the application to use out-of-band from the application's startup.
* `FLYWAY_URL`, `FLYWAY_USER`, `FLYWAY_PASSWORD` can be overridden in, say, a k8s ConfigMap (Spring Boot being 12-factor friendly is nice 😃 ).
* I can switch `application.yml` back to `application.properties` if that's preferred.  I switched to YAML because I prefer that format over `.properties`.