### PR TITLE
Adding liveness and readiness probes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mysql:5.7.21
     environment:
       MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: java_prototype
-      MYSQL_PASSWORD: java_prototype
+      MYSQL_USER: java-prototype
+      MYSQL_PASSWORD: java-prototype
     ports:
       - "3306:3306"

--- a/java-prototype/templates/deployment.yaml
+++ b/java-prototype/templates/deployment.yaml
@@ -24,13 +24,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if .Values.localDevEnvironment }}
+            - name: FLYWAY_URL
+              value: {{ .Values.env.flyway.conn}}
+            - name: FLYWAY_USER
+              value: {{ .Values.env.flyway.user}}
+            - name: FLYWAY_PASSWORD
+              value: {{ .Values.env.flyway.pass}}
             - name: JAVAPROTOTYPE_MYSQL_CONNECTION_STRING
-              value: "jdbc:mysql://localhost:3306/java_prototype"
-            {{- else }}
-            - name: JAVAPROTOTYPE_MYSQL_CONNECTION_STRING
-              value: {{  .Values.conn }}
-            {{- end }}
+              value: {{  .Values.env.conn }}
             - name: JAVAPROTOTYPE_MYSQL_CONNECTION_STRING
               value: {{ .Values.env.conn }}
             - name: JAVAPROTOTYPE_MYSQL_CONNECTION_USER
@@ -43,18 +44,16 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     host: 127.0.0.1
-          #     port: http
-          #   initialDelaySeconds: 120
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     host: 127.0.0.1
-          #     port: http
-          #   initialDelaySeconds: 120
+          livenessProbe:
+            httpGet:
+              path: /info
+              port: 8080
+            initialDelaySeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/java-prototype/values.yaml
+++ b/java-prototype/values.yaml
@@ -5,14 +5,18 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/farmotive-io/java-prototype #Replace `farmotive-io` with your $PROJECT_ID
-  tag: latest
-  pullPolicy: Always
+  repository: billkoch/heptio-java-prototype
+  tag: issue-34
+  pullPolicy: IfNotPresent
 
 env:
   conn: "jdbc:mysql://java-prototype-mysql-mysql:3306/java-prototype"
   user: "java-prototype"
   pass: "heptio"
+  flyway:
+    conn: "jdbc:mysql://java-prototype-mysql-mysql:3306"
+    user: root # replace with user that has elevated privileges (grant,create,drop,etc.)
+    pass: root
   javaopts: "-Xmx2048m"
 
 localDevEnvironment: false # Change to true if deploy locally

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-amqp</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-cloud-connectors</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,10 @@ debug: true
 
 spring:
   datasource:
-    url: ${JAVAPROTOTYPE_MYSQL_CONNECTION_STRING:jdbc:mysql://localhost:3306/java_prototype}
+    url: ${JAVAPROTOTYPE_MYSQL_CONNECTION_STRING:jdbc:mysql://localhost:3306/java-prototype}
     driver-class-name: com.mysql.jdbc.Driver
-    username: ${JAVAPROTOTYPE_MYSQL_CONNECTION_USER:java_prototype}
-    password: ${JAVAPROTOTYPE_MYSQL_CONNECTION_PASS:java_prototype}
+    username: ${JAVAPROTOTYPE_MYSQL_CONNECTION_USER:java-prototype}
+    password: ${JAVAPROTOTYPE_MYSQL_CONNECTION_PASS:java-prototype}
 
   jackson.serialization.WRITE_DATES_AS_TIMESTAMPS: false
 
@@ -16,6 +16,6 @@ management:
 
 flyway:
   url: jdbc:mysql://localhost:3306
-  schemas: java_prototype
+  schemas: java-prototype
   placeholders:
     application_username: ${spring.datasource.username}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     username: ${JAVAPROTOTYPE_MYSQL_CONNECTION_USER:java_prototype}
     password: ${JAVAPROTOTYPE_MYSQL_CONNECTION_PASS:java_prototype}
 
+management.security.enabled: false
+
 flyway:
   url: jdbc:mysql://localhost:3306
   schemas: java_prototype

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,11 @@ spring:
     username: ${JAVAPROTOTYPE_MYSQL_CONNECTION_USER:java_prototype}
     password: ${JAVAPROTOTYPE_MYSQL_CONNECTION_PASS:java_prototype}
 
-management.security.enabled: false
+  jackson.serialization.WRITE_DATES_AS_TIMESTAMPS: false
+
+management:
+  security.enabled: false # allows unauthenticated access to the spring-boot-actuator endpoints
+  info.git.mode: full # (simple | full) -- controls how much of the git.properties information is returned in the /info endpoint
 
 flyway:
   url: jdbc:mysql://localhost:3306

--- a/src/main/resources/db/migration/V1__create_getrequests_table.sql
+++ b/src/main/resources/db/migration/V1__create_getrequests_table.sql
@@ -1,7 +1,7 @@
 
-GRANT delete, insert, select, update ON java_prototype.* TO `${application_username}`;
+GRANT delete, insert, select, update ON java-prototype.* TO `${application_username}`;
 
--- Create syntax for 'java_prototype.getrequests'
+-- Create syntax for 'java-prototype.getrequests'
 CREATE TABLE getrequests (
   id int(11) unsigned NOT NULL AUTO_INCREMENT,
   timestamp timestamp NULL DEFAULT NULL,

--- a/src/main/resources/db/migration/V1__create_getrequests_table.sql
+++ b/src/main/resources/db/migration/V1__create_getrequests_table.sql
@@ -1,5 +1,5 @@
 
-GRANT delete, insert, select, update ON java_prototype.* TO ${application_username};
+GRANT delete, insert, select, update ON java_prototype.* TO `${application_username}`;
 
 -- Create syntax for 'java_prototype.getrequests'
 CREATE TABLE getrequests (


### PR DESCRIPTION
This PR is intended to resolve https://github.com/heptio/java-prototype/issues/34

I'm leveraging _**a lot**_ of Spring Boot goodness here, so hopefully that's ok.  If you'd like to have the liveness/readiness probes come from something more homegrown, I'd be happy to take another crack at it.

## Liveness Probe
* Uses a `/info` HTTP endpoint which is provided by spring-boot-actuator
* I'm augmenting the `/info` endpoint with git-related metadata through the Maven `git-commit-id`  plugin
* Sample response:
```
HTTP/1.1 200
Content-Type: application/vnd.spring-boot.actuator.v1+json;charset=UTF-8
Date: Sat, 10 Mar 2018 06:13:10 GMT
Transfer-Encoding: chunked
X-Application-Context: application:8080

{
    "git": {
        "branch": "issue-34",
        "build": {
            "host": "3c9cea5a8365",
            "time": "2018-03-10T06:09:38.000+0000",
            "user": {
                "email": "",
                "name": ""
            },
            "version": "0.0.1.BUILD-SNAPSHOT"
        },
        "closest": {
            "tag": {
                "commit": {
                    "count": ""
                },
                "name": ""
            }
        },
        "commit": {
            "id": "1a7850f26a71638164cf41ddae2792db676f3644",
            "id.abbrev": "1a7850f",
            "id.describe": "1a7850f",
            "id.describe-short": "1a7850f",
            "message": {
                "full": "Escaping the username in the flyway migration script to account for usernames that contain '-' characters\n\nSigned-off-by: Bill Koch <koch.149@osu.edu>",
                "short": "Escaping the username in the flyway migration script to account for usernames that contain '-' characters"
            },
            "time": "2018-03-10T05:48:42.000+0000",
            "user": {
                "email": "koch.149@osu.edu",
                "name": "Bill Koch"
            }
        },
        "dirty": "false",
        "remote": {
            "origin": {
                "url": "git@github.com:billkoch/java-prototype.git"
            }
        },
        "tags": ""
    }
}
```
 ## Readiness Probe
* Uses the `/health` HTTP endpoint which is also provided by spring-boot-actuator
*  Actuator will dynamically define HealthIndicators based upon which Spring classes are on the classpath
   * For example, if Spring's Redis jar is on the classpath, you will get a HealthIndicator for Redis automatically
   * Because of this auto-registration, I removed the `spring-boot-starter-data-redis` and `spring-boot-starter-amqp` dependencies (since they don't appear to be needed)
   * [List of available HealthIndicators that Spring provides out-of-the-box](https://docs.spring.io/spring-boot/docs/1.5.10.RELEASE/reference/htmlsingle/#_auto_configured_healthindicators)
* Sample response:
```
HTTP/1.1 200
Content-Type: application/vnd.spring-boot.actuator.v1+json;charset=UTF-8
Date: Sat, 10 Mar 2018 06:30:58 GMT
Transfer-Encoding: chunked
X-Application-Context: application:8080

{
    "db": {
        "database": "MySQL",
        "hello": 1,
        "status": "UP"
    },
    "diskSpace": {
        "free": 14578130944,
        "status": "UP",
        "threshold": 10485760,
        "total": 17293533184
    },
    "status": "UP"
}
```
## Testing on minikube
I vetted this on minikube with helm commands similar to the README.md:
```
$ helm install stable/mysql --name java-prototype-mysql \
  --set mysqlRootPassword=root \
  --set mysqlUser=java-prototype \
  --set mysqlPassword=heptio \
  --set mysqlDatabase=java-prototype

$ helm install java-prototype --name java-prototype
```